### PR TITLE
The mighty quest for consistency

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -14,12 +14,18 @@
       </a>
 
       <div class="trigger">
+        <a class="page-link" href="https://devices.ubports.com/">Devices</a>
+        <a class="page-link" href="https://forums.ubports.com/">Forums</a>
+        <a class="page-link" href="https://wiki.ubports.com/">Wiki</a>
+        <a class="page-link" href="https://blog.ubports.com/">Blog</a>
+        <a class="page-link" href="https://ubports.com/get-involved">Get Involved</a>
+        <a class="page-link" href="https://ubports.com/sponsors">Sponsors</a>
+        <a class="page-link" href="https://ubports.com/team">Team</a>
         {% for my_page in site.pages %}
           {% if my_page.title %}
           <a class="page-link" href="{{ my_page.url | prepend: site.baseurl }}">{{ my_page.title }}</a>
           {% endif %}
         {% endfor %}
-        <a class="page-link" href="https://devices.ubports.com/">Devices</a>
       </div>
     </nav>
 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -19,6 +19,7 @@
           <a class="page-link" href="{{ my_page.url | prepend: site.baseurl }}">{{ my_page.title }}</a>
           {% endif %}
         {% endfor %}
+        <a class="page-link" href="https://devices.ubports.com/">Devices</a>
       </div>
     </nav>
 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -2,7 +2,7 @@
 
   <div class="wrapper">
 
-    <a class="site-title" href="{{ site.baseurl }}/">{{ site.title }}</a>
+    <a class="site-title" href="https://ubports.com/">UBports</a>
 
     <nav class="site-nav">
       <a href="#" class="menu-icon">

--- a/about.md
+++ b/about.md
@@ -1,7 +1,0 @@
----
-layout: page
-title: About
-permalink: /about/
----
-
-UBports is a team of developers and a meeting place for developers that wish to port Ubuntu Touch to as many devices as possible, this is a place where developers can talk to other developers, learn from each other and help push Ubuntu to more devices as a team, or by yourself but with community support if you wish. [ubports.com](http://ubports.com/)


### PR DESCRIPTION
I Modified the primary navigation on the blog to have the same links as all the other UBports sites.

- Added links to Devices, Forums, Wiki, Blog, Get Involved, Sponsors and Team
- Removed about page as it was redundant
- Changed the page title to UBports and pointed it to link to ubports.com rather than blog.ubports.com